### PR TITLE
Added integration method for model

### DIFF
--- a/gravann/__init__.py
+++ b/gravann/__init__.py
@@ -11,7 +11,7 @@ from ._encodings import directional_encoding, positional_encoding, direct_encodi
 from ._losses import normalized_loss, mse_loss, normalized_L1_loss, contrastive_loss, normalized_sqrt_L1_loss
 
 # Importing the method to integrate the density rho(x,y,z) output of an ANN in the unit cube
-from ._integration import ACC_ld, ACC_trap, U_mc, U_ld, U_trap_opt
+from ._integration import ACC_ld, ACC_trap, U_mc, U_ld, U_trap_opt, rho_trap
 from ._integration import sobol_points, compute_integration_grid
 
 # Importing misc methods for 3D graphics

--- a/gravann/_integration.py
+++ b/gravann/_integration.py
@@ -16,6 +16,44 @@ sobol_points = sobol_seq.i4_sobol_generate(3, 200000)
 # Naive Montecarlo method for the potential
 
 
+def rho_trap(model, encoding, mask, c, N=10000):
+    """Compute integral over the model where points matching some mask are set to 0
+
+    Args:
+        model (callable (a,b)->1): neural model for the asteroid. 
+        encoding: the encoding for the neural inputs.
+        mask (func): a function that given [N,3] returns a [N] torch.tensor bool as mask
+        c (float): scaling factor for model rho
+        N (int, optional): Integration grid points. Defaults to 10000.
+
+    Returns:
+        torch.tensor: integral value
+    """
+    # clean up memory to ensure we have space
+    torch.cuda.empty_cache()
+
+    # create integration grid
+    sample_points, h, N = compute_integration_grid(N)
+
+    # Evaluate Rho on the grid
+    rho = _compute_model_output(
+        model, encoding, sample_points) * c
+
+    rho[mask(sample_points)] = 0.0
+
+    evaluations = rho.reshape([N, N, N])  # map to z,y,x
+
+    # area = h / 2 * (f0 + f2)
+    int_x = h[0] / 2 * (evaluations[:, :, 0:-1] + evaluations[:, :, 1:])
+    int_x = torch.sum(int_x, dim=2)
+    int_y = h[1] / 2 * (int_x[:, 0:-1] + int_x[:, 1:])
+    int_y = torch.sum(int_y, dim=1)
+    int_z = h[2] / 2 * (int_y[0:-1] + int_y[1:])
+    int_z = torch.sum(int_z, dim=0)
+
+    return int_z
+
+
 def U_mc(target_points, model, encoding=direct_encoding(), N=3000, domain=None):
     """Plain Monte Carlo evaluation of the potential from the modelled density
 


### PR DESCRIPTION
Implemented as discussed.

Can be used like this

```python
mask = lambda x: 0.5*x[:,0]+0.1*x[:,1]+0.2*x[:,2]+0.33 > 0 #define some cutting plane
gravann.rho_trap(model,encoding,mask,c) #compute integral
```

Closes #63 